### PR TITLE
openhab-get fix for OH3

### DIFF
--- a/77-openhab2.js
+++ b/77-openhab2.js
@@ -236,6 +236,7 @@ module.exports = function(RED) {
             else
             {
             	url = getConnectionString(config) + "/rest/items/" + itemname;
+		    		headers = {};
             	method = request.get;
             }
 


### PR DESCRIPTION
fix for issue #54
Openhab-get node throws 'Reference Error: headers is not defined'
Added a headers variable to the last branch for sending the request to openhab.